### PR TITLE
Use directory-files instead of depending on ls

### DIFF
--- a/dwim-shell-command.el
+++ b/dwim-shell-command.el
@@ -811,7 +811,9 @@ Use OVERRIDE to override `default-directory'."
   (when-let ((default-directory (or override default-directory)))
     (seq-map (lambda (filename)
                (file-name-concat default-directory filename))
-             (process-lines "ls" "-1"))))
+             (cl-remove-if
+              (lambda (e) (member e '("." "..")))
+              (directory-files default-directory)))))
 
 (defun dwim-shell-command--last-modified-between (before after)
   "Compare files in BEFORE and AFTER and return oldest file in diff."


### PR DESCRIPTION
This makes it work on windows where ls may not be available.  I'm no emacs lisp expert so there may be a more idiomatic way of doing this.

Thanks for the library.  On a related not started using [ebb and flow](https://github.com/howardabrams/hamacs/blob/main/ha-eshell.org#ebb-and-flow-output-to-emacs-buffers) in eshell a few months back and its great.