### PR TITLE
fix dwim-shell-commands-open-externally on linux for non standard shells

### DIFF
--- a/dwim-shell-commands.el
+++ b/dwim-shell-commands.el
@@ -707,7 +707,8 @@ ffmpeg -n -i '<<f>>' -vf \"scale=$width:-2\" '<<fne>>_x<<Scaling factor:0.5>>.<<
            (format "xed --line %d '<<f>>'"
                    (line-number-at-pos (point)))
          "open '<<f>>'")
-     "setsid -w xdg-open '<<f>>'")
+     "xdg-open '<<f>>'")
+   :shell-util "zsh"
    :shell-args '("-x" "-c")
    :silent-success t
    :utils (if (eq system-type 'darwin)


### PR DESCRIPTION
https://github.com/xenodium/dwim-shell-command/issues/12

Change the function to use a different shell, as mentioned in the issue, when using the fish shell, this function doesn't currently work

previously the `setsid` method worked but since then, new default shell-args were added which fish isn't compatible with, so defaulting to a shell that does accept them seems the easier solution