### PR TITLE
Make dwim-shell-commands-kdeconnect-share list devices

### DIFF
--- a/README.org
+++ b/README.org
@@ -326,7 +326,7 @@ Here are all the commands I've added so far...
 | dwim-shell-commands-join-as-pdf                              | Join all marked images as a single pdf.                                   |
 | dwim-shell-commands-join-images-horizontally                 | Join all marked images horizontally as a single image.                    |
 | dwim-shell-commands-join-images-vertically                   | Join all marked images vertically as a single image.                      |
-| dwim-shell-command-kdeconnect-share                          | Send file(s) to DEVICE through KDE Connect.                               |
+| dwim-shell-commands-kdeconnect-share                         | Send file(s) to DEVICE through KDE Connect.                               |
 | dwim-shell-commands-keep-pdf-page                            | Keep a page from pdf.                                                     |
 | dwim-shell-commands-kill-gpg-agent                           | Kill (thus restart) gpg agent.                                            |
 | dwim-shell-commands-kill-process                             | Select and kill process.                                                  |

--- a/dwim-shell-commands.el
+++ b/dwim-shell-commands.el
@@ -358,13 +358,15 @@ Optional argument ARGS as per `browse-url-default-browser'"
    :utils "convert"))
 
 ;;;###autoload
-(defun dwim-shell-commands-kdeconnect-share (device)
-    "Send file(s) to DEVICE through KDE Connect."
-    (interactive "sDevice: ")
+(defun dwim-shell-commands-kdeconnect-share ()
+  "Send file(s) to a device through KDE Connect."
+  (interactive)
+  (let* ((devices (process-lines "kdeconnect-cli" "--list-available" "--name-only"))
+         (device (completing-read "Device: " devices nil t)))
     (dwim-shell-command-on-marked-files
      "Send file(s) to DEVICE through KDE Connect."
-     (concat "kdeconnect-cli -n '" device "' --share '<<f>>'")
-     :utils "kdeconnect-cli"))
+     (format "kdeconnect-cli -n '%s' --share '<<f>>'" device)
+     :utils "kdeconnect-cli")))
 
 ;;;###autoload
 (defun dwim-shell-commands-keep-pdf-page ()


### PR DESCRIPTION
https://github.com/user-attachments/assets/759b97c9-aba3-4c47-8e58-fc9798fcd21b

Use `completing-read` to pick a device from a list of devices provided
by `kdeconnect-cli.`