### PR TITLE
reveal with finder: Replace the swift script by a call to `open -R`

### DIFF
--- a/dwim-shell-commands.el
+++ b/dwim-shell-commands.el
@@ -1220,12 +1220,10 @@ echo \"<<fne>>.svg\"
   (interactive)
   (dwim-shell-command-on-marked-files
    "Reveal in Finder"
-   "import AppKit
-    NSWorkspace.shared.activateFileViewerSelecting([\"<<*>>\"].map{URL(fileURLWithPath:$0)})"
+   "open -R '<<*>>'"
    :silent-success t
-   :shell-pipe "swift -"
-   :join-separator ", "
-   :utils "swift"))
+   :no-progress t
+   :utils "open"))
 
 (defun dwim-shell-commands--macos-sharing-services ()
   "Return a list of sharing services."


### PR DESCRIPTION
The existing implementation wasn't working for me and I couldn't debug why.

  - the output showed something like:
  
  ```
  2026-01-09 11:03:59.171 swift-frontend[96195:69954069] Pasteboard contained types (), but service expects types (
      "public.utf8-plain-text",
      "dyn.agu8y6y4grf0gn5xbrzw1gydcr7u1e3cytf2gn",
      "public.url",
      "com.apple.cocoa.pasteboard.multiple-text-selection"
  )
  ```
  - the share command which use the same pattern to pass the files works (on the same file/selection that reveal failed on)
  
It seems the `open -R` is the standard approach any way and seems simpler/faster.